### PR TITLE
ci: set least-privilege top-level token permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,11 @@ on:
     # Weekly, Monday 03:00 UTC.
     - cron: "0 3 * * 1"
 
+# Default the workflow token to read-only; the analyze job escalates only
+# the scopes it needs (security-events: write) at job level.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,6 +9,10 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+# Hassfest and HACS only need to read repository contents.
+permissions:
+  contents: read
+
 jobs:
   hassfest:
     name: Hassfest


### PR DESCRIPTION
Add a top-level permissions: contents: read default to the CodeQL and Validate workflows. Only the Scorecard workflow declared top-level permissions; without one the workflow token inherits the repository default, which the OpenSSF Scorecard Token-Permissions check flags as excessive. The CodeQL analyze job keeps its job-level security-events: write.

Tests: both workflows parse (yaml.safe_load); no behavior change, read-only default with unchanged job-level scopes.